### PR TITLE
Add eligibility calculator decommission page

### DIFF
--- a/views/civil-eligibility-calculator.justice.gov.uk.erb
+++ b/views/civil-eligibility-calculator.justice.gov.uk.erb
@@ -1,0 +1,16 @@
+<% content_for :title do %>
+    Civil Legal Aid Eligibility Calculator
+  <% end %>
+  
+  <% content_for :main_content do %>
+    <h1>Civil Legal Aid Eligibility Calculator</h1>
+    <p>
+      The eligibility calculator tool is no longer in use.
+    </p>
+    <p> 
+      Legal aid providers wishing to check financial eligibility for legal aid are asked to use the resources on the <a href="https://www.gov.uk/guidance/civil-legal-aid-means-testing">GOV.UK means testing page.</a>
+    </p>
+    <p>
+      Members of the public wishing to check their eligibility should use the <a href="https://www.gov.uk/check-legal-aid">legal aid checker.</a>
+    </p>
+  <% end %>


### PR DESCRIPTION
Created new page for civil-eligibility-calculator.justice.gov.uk.

This is a page for the currently decommissioned Eligibility Calculator.