### PR TITLE
Update GA Tag Details

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -3,13 +3,13 @@
 <!--[if gt IE 8]><!--><html lang="en"><!--<![endif]-->
 <head>
   <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-4NR0GMRPNF"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XP576YJ2C8"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'G-4NR0GMRPNF');
+    gtag('config', 'G-XP576YJ2C8');
   </script>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
   <title><%= yield_content :title %></title>


### PR DESCRIPTION
GA Property for this site has been migrated to another GA Account. This change updates tags to send analytics data to the new account.