### PR TITLE
Create operations-engineering.service.justice.gov.uk redirection page

### DIFF
--- a/views/operations-engineering.service.justice.gov.uk.erb
+++ b/views/operations-engineering.service.justice.gov.uk.erb
@@ -1,0 +1,12 @@
+<% content_for :title do %>
+  Decommission Notice
+<% end %>
+
+<% content_for :main_content do %>
+  <h1>Decommission Notice</h1>
+  <p>
+    This domain has been decommissioned.
+
+    Please head to the new <a href="https://user-guide.operations-engineering.service.justice.gov.uk/#moj-operations-engineering-user-guide">Operations Engineering User Guide</a> site.
+  </p>
+<% end %>


### PR DESCRIPTION
## 👀 Purpose

- As we can't redirect the old Operations Engineering domain to the new user docs site via GitHub pages (as you can only have a single domain per document site), we have created a redirection page that tells users where the new user guide site can be found.

## ♻️ What's changed

- New redirection page added to maintenance pages app