### PR TITLE
✨ Add Environment Configuration to Default to `production`

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -4,6 +4,8 @@ require "bundler/setup"
 require "sinatra"
 require "sinatra/content_for"
 
+set :environment, :production
+
 get "*" do
   erb request.host.to_sym
 end


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4792
- To ensure that the production application uses the production environment setting which comes with some sensible default configurations as defined [here](https://sinatrarb.com/configuration.html)

## ♻️ What's changed

- Set the environment to `production`

## 📝 Notes

- As specified in the [configuration documentation](https://sinatrarb.com/configuration.html), the default environment for a Sinatra application is development, which enables some features such as :show_exceptions, which is not desirable in a production environment