### PR TITLE
🔧 Fix Deployment by Passing Through `ECR_REPOSITORY` Environment Variable

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,7 @@ env:
   KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
   KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
 
+  ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
   IMAGE_TAG: ${{ github.sha }}
 
 jobs:
@@ -34,7 +35,6 @@ jobs:
           docker push ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
 
       - name: Update image tag
         run: cat kubernetes_deployment/live/deployment.tpl | envsubst > kubernetes_deployment/live/deployment.yaml

--- a/kubernetes_deployment/live/deployment.tpl
+++ b/kubernetes_deployment/live/deployment.tpl
@@ -15,6 +15,6 @@ spec:
     spec:
       containers:
         - name: sinatra-app
-          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/${ECR_NAME}:${IMAGE_TAG}
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/${ECR_REPOSITORY}:${IMAGE_TAG}
           ports:
           - containerPort: 4567


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4792
- To fix incorrect image name when image is deployed to Kubernetes

## ♻️ What's changed

- Added `ECR_REPOSITORY` as a global environment variable
- Aligned naming in the `deployment.tpl` for consistency
