### PR TITLE
🔥 Remove Unused Ingress `maintenance-pages-demo.apps.live.cloud-platform.service.justice.gov.uk`

### DIFF
--- a/kubernetes_deployment/live/ingress.yaml
+++ b/kubernetes_deployment/live/ingress.yaml
@@ -14,16 +14,6 @@ spec:
         - "civil-eligibility-calculator.justice.gov.uk"
       secretName: domains-secret
   rules:
-    - host: maintenance-pages-demo.apps.live.cloud-platform.service.justice.gov.uk
-      http:
-        paths:
-          - backend:
-              service:
-                name: maintenance-pages-service
-                port:
-                  number: 4567
-            path: /
-            pathType: ImplementationSpecific
     - host: maintenance-page.cloud-platform.service.justice.gov.uk
       http:
         paths:


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4792
- To remove unused ingress

## ♻️ What's changed

- Removed Ingres for `maintenance-pages-demo.apps.live.cloud-platform.service.justice.gov.uk`

## 📝 Notes

- This ingress does not have a related view and therefore just throws an error. Since we are looking to decommission the app, we prefer to remove over fix.