### PR TITLE
🔐 Configure Rack Protection Middleware

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -9,7 +9,7 @@ set :environment, :production
 use Rack::Protection
 use Rack::Protection::FrameOptions
 use Rack::Protection::ContentSecurityPolicy, 
-  default_src: "'self' 'unsafe-inline' data: https://region1.google-analytics.com https://www.googletagmanager.com",
+  default_src: "'self' 'unsafe-inline' data: https://region1.google-analytics.com https://www.googletagmanager.com"
 use Rack::Protection::XSSHeader
 use Rack::Protection::StrictTransport
 

--- a/app.rb
+++ b/app.rb
@@ -8,7 +8,7 @@ set :environment, :production
 
 use Rack::Protection
 use Rack::Protection::FrameOptions
-use Rack::Protection::ContentSecurityPolicy, 
+use Rack::Protection::ContentSecurityPolicy,
   default_src: "'self' 'unsafe-inline' data: https://region1.google-analytics.com https://www.googletagmanager.com"
 use Rack::Protection::XSSHeader
 use Rack::Protection::StrictTransport

--- a/app.rb
+++ b/app.rb
@@ -6,6 +6,13 @@ require "sinatra/content_for"
 
 set :environment, :production
 
+use Rack::Protection
+use Rack::Protection::FrameOptions
+use Rack::Protection::ContentSecurityPolicy, 
+  default_src: "'self' 'unsafe-inline' data: https://region1.google-analytics.com https://www.googletagmanager.com",
+use Rack::Protection::XSSHeader
+use Rack::Protection::StrictTransport
+
 get "*" do
   erb request.host.to_sym
 end


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4792
- To ensure basic security headers are configured to protect against well known web application vulnerabilities

## ♻️ What's changed

- Configured rack-protection middleware which configures several headers to protect against common web application vulnerabilities

## 📝 Notes

- Ran locally, and the headers don't affect the loading of the application, specifically the CSP does not prevent any content being loaded or block communication with Google Analytics